### PR TITLE
hotfix: set utf-8 encoding for log file write to prevent UnicodeEncodeError

### DIFF
--- a/backend/app/visitor_logger.py
+++ b/backend/app/visitor_logger.py
@@ -40,7 +40,7 @@ class VisitorLogger:
             log_entry += f",{additional_info}"
 
         log_file = self._get_log_file()
-        with open(log_file, "a") as f:
+        with open(log_file, "a", encoding="utf-8") as f:
             f.write(log_entry + "\n")
 
     def get_logs(self, date: Optional[str] = None, max_entries: Optional[int] = None):


### PR DESCRIPTION
Fix ``UnicodeEncodeError: 'charmap' codec can't encode characters in position 35-40: character maps to <undefined>`` Error