### PR TITLE
Fix wrong dialog opening by properly managing API response handlers

### DIFF
--- a/frontend/app/views/logs/logs_dialog.py
+++ b/frontend/app/views/logs/logs_dialog.py
@@ -2,6 +2,7 @@ from PySide6.QtWidgets import QDialog, QVBoxLayout, QListWidget, QLabel
 from datetime import datetime
 from app.views.common.warning_dialog import show_warning
 
+
 class LogsDialog(QDialog):
     def __init__(self, logs, parent=None):
         super().__init__(parent)
@@ -17,7 +18,7 @@ class LogsDialog(QDialog):
                 "✓ Visitor has no recorded logs\n"
                 "✓ Visitor was created before build bf46edd — visitor creation date may be missing\n\n"
                 "Technical details:\n"
-                f"• {message}"
+                f"• {message}",
             )
         else:
             layout = QVBoxLayout()

--- a/frontend/app/views/logs/logs_dialog.py
+++ b/frontend/app/views/logs/logs_dialog.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QListWidget, QLabel
 from datetime import datetime
-
+from app.views.common.warning_dialog import show_warning
 
 class LogsDialog(QDialog):
     def __init__(self, logs, parent=None):
@@ -8,15 +8,27 @@ class LogsDialog(QDialog):
         self.setWindowTitle("Logs")
         self.setMinimumSize(500, 400)
 
-        layout = QVBoxLayout()
-        self.logs_list = QListWidget()
+        if not isinstance(logs, list):
+            message = logs.get("message", "No logs available")
+            show_warning(
+                "No Logs Found",
+                "Could not retrieve logs for this visitor.\n\n"
+                "Possible reasons:\n"
+                "✓ Visitor has no recorded logs\n"
+                "✓ Visitor was created before build bf46edd — log creation date may be missing\n\n"
+                "Technical details:\n"
+                f"• {message}"
+            )
+        else:
+            layout = QVBoxLayout()
+            self.logs_list = QListWidget()
 
-        for log in logs:
-            ts = datetime.fromisoformat(log["timestamp"])
-            formatted = ts.strftime("%H:%M:%S %d/%m/%Y")
-            entry = f"{formatted} - {log['visitor_dbid']} - {log['visitor_name']} - {log['action']} "
-            self.logs_list.addItem(entry)
+            for log in logs:
+                ts = datetime.fromisoformat(log["timestamp"])
+                formatted = ts.strftime("%H:%M:%S %d/%m/%Y")
+                entry = f"{formatted} - {log['visitor_dbid']} - {log['visitor_name']} - {log['action']}"
+                self.logs_list.addItem(entry)
 
-        layout.addWidget(QLabel("Recent Logs:"))
-        layout.addWidget(self.logs_list)
-        self.setLayout(layout)
+            layout.addWidget(QLabel("Recent Logs:"))
+            layout.addWidget(self.logs_list)
+            self.setLayout(layout)

--- a/frontend/app/views/logs/logs_dialog.py
+++ b/frontend/app/views/logs/logs_dialog.py
@@ -15,7 +15,7 @@ class LogsDialog(QDialog):
                 "Could not retrieve logs for this visitor.\n\n"
                 "Possible reasons:\n"
                 "✓ Visitor has no recorded logs\n"
-                "✓ Visitor was created before build bf46edd — log creation date may be missing\n\n"
+                "✓ Visitor was created before build bf46edd — visitor creation date may be missing\n\n"
                 "Technical details:\n"
                 f"• {message}"
             )

--- a/frontend/app/views/main_window.py
+++ b/frontend/app/views/main_window.py
@@ -148,7 +148,11 @@ class MainWindow(QMainWindow):
         self.logger.write_to_log(f"Error: {error}")
 
     def force_sync(self):
-        self.logger.write_to_log("Manual sync initiated...")
+        try:
+            self.api_client.response_received.disconnect()
+        except TypeError:
+            pass
+        self.api_client.response_received.connect(self.handle_get_visitors)
         self.api_client.get_visitors_inside()
 
     def open_search_dialog(self):
@@ -234,7 +238,10 @@ class MainWindow(QMainWindow):
         QApplication.quit()
 
     def open_logs_dialog(self):
-        self.api_client.response_received.disconnect()
+        try:
+            self.api_client.response_received.disconnect()
+        except TypeError:
+            pass
         self.api_client.response_received.connect(self.handle_logs_response)
         self.api_client.get_logs(limit=20)
 


### PR DESCRIPTION
* Ensure `response_received` signal disconnects previous handlers before connecting new ones
* Prevents `force_sync` from triggering logs dialog and vice versa