### PR TITLE
Feat/modify existing visitors - Add visitor modification functionality

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -133,3 +133,22 @@ def search_visitors_by_key_value(db: Session, key: str, value: str = None):
             == value
         )
     return query.all()
+
+
+def update_visitor_details(db: Session, visitor_id: str, name: str = None, visitorid: str = None, properties: dict = None):
+    visitor = (
+        db.query(models.Visitor).filter(models.Visitor.visitorid == visitor_id).first()
+    )
+
+    if visitor:
+        if name is not None:
+            visitor.name = name
+        if visitorid is not None:
+            visitor.visitorid = visitorid
+        if properties is not None:
+            visitor.properties = properties
+        db.commit()
+        db.refresh(visitor)
+        log_visitor_action(db, visitor.dbid, "update")
+        return visitor
+    return None

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -135,7 +135,13 @@ def search_visitors_by_key_value(db: Session, key: str, value: str = None):
     return query.all()
 
 
-def update_visitor_details(db: Session, visitor_id: str, name: str = None, visitorid: str = None, properties: dict = None):
+def update_visitor_details(
+    db: Session,
+    visitor_id: str,
+    name: str = None,
+    visitorid: str = None,
+    properties: dict = None,
+):
     visitor = (
         db.query(models.Visitor).filter(models.Visitor.visitorid == visitor_id).first()
     )

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -180,14 +180,14 @@ def get_logs_for_visitor(visitor_id: str, db: Session = Depends(database.get_db)
 async def update_visitor(
     visitor_id: str,
     visitor: schemas.VisitorUpdate,
-    db: Session = Depends(database.get_db)
+    db: Session = Depends(database.get_db),
 ):
     updated_visitor = crud.update_visitor_details(
         db=db,
         visitor_id=visitor_id,
         name=visitor.name,
         visitorid=visitor.visitorid,
-        properties=visitor.properties
+        properties=visitor.properties,
     )
 
     if not updated_visitor:
@@ -197,7 +197,7 @@ async def update_visitor(
         event_type="UPDATE",
         visitor_id=updated_visitor.visitorid,
         visitor_name=updated_visitor.name,
-        additional_info=f"Updated properties: {updated_visitor.properties}"
+        additional_info=f"Updated properties: {updated_visitor.properties}",
     )
 
     try:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -19,7 +19,6 @@ class VisitorBase(VisitorCreate):
 class VisitorUpdate(BaseModel):
     name: Optional[str] = None
     visitorid: Optional[str] = None
-    inside: Optional[bool] = None
     properties: Optional[Dict] = Field(default_factory=dict)
 
     class Config:

--- a/frontend/app/core/api_client.py
+++ b/frontend/app/core/api_client.py
@@ -98,6 +98,13 @@ class ApiClient(QObject):
         ApiClient.logger.write_to_log(f"GET request to {url} for visitor logs")
         self._send_request(url, "GET")
 
+    def update_visitor(self, visitor_id: str, visitor_data: dict):
+        url = Settings.get_http_url(f"/visitors/{visitor_id}")
+        ApiClient.logger.write_to_log(
+            f"PUT request to {url} with visitor data: {visitor_data}"
+        )
+        self._send_request(url, "PUT", visitor_data)
+
     def _send_request(self, url: str, method: str, data: dict = None):
         request = QNetworkRequest(QUrl(url))
         request.setHeader(QNetworkRequest.ContentTypeHeader, "application/json")
@@ -111,6 +118,12 @@ class ApiClient(QObject):
                 f"POST request to {url} with data: {json.dumps(data)}"
             )
             self.manager.post(request, json_data)
+        elif method == "PUT":
+            json_data = QJsonDocument.fromVariant(data).toJson()
+            ApiClient.logger.write_to_log(
+                f"PUT request to {url} with data: {json.dumps(data)}"
+            )
+            self.manager.put(request, json_data)
 
     @Slot(object)
     def _handle_response(self, reply):

--- a/frontend/app/views/visitor/edit_visitor_dialog.py
+++ b/frontend/app/views/visitor/edit_visitor_dialog.py
@@ -1,0 +1,237 @@
+import sys
+from pathlib import Path
+
+if __name__ == "__main__" and not __package__:
+    file = Path(__file__).resolve()
+    package_root = file.parents[3]
+    sys.path.append(str(package_root))
+    __package__ = "frontend.app.views"
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QScrollArea,
+    QWidget,
+    QFrame,
+    QApplication,
+    QCheckBox,
+    QDialogButtonBox,
+)
+from PySide6.QtCore import Qt
+
+from app.core.api_client import ApiClient
+from app.views.common.warning_dialog import show_warning
+
+
+class EditVisitorDialog(QDialog):
+    def __init__(self, visitor_data, parent=None):
+        super().__init__(parent)
+        self.visitor_data = visitor_data
+        self.api_client = ApiClient.get_instance()
+        
+        self.setWindowTitle("Edit Visitor")
+        self.setMinimumSize(500, 600)
+        
+        self.setup_ui()
+        
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+        
+        basic_frame = QFrame()
+        basic_frame.setFrameShape(QFrame.StyledPanel)
+        basic_layout = QVBoxLayout(basic_frame)
+        basic_layout.setContentsMargins(12, 12, 12, 12)
+        
+        name_layout = QHBoxLayout()
+        name_label = QLabel("Name:")
+        self.name_input = QLineEdit()
+        self.name_input.setText(self.visitor_data['name'])
+        name_layout.addWidget(name_label)
+        name_layout.addWidget(self.name_input)
+        basic_layout.addLayout(name_layout)
+        
+        id_layout = QHBoxLayout()
+        id_label = QLabel("Visitor ID:")
+        self.id_input = QLineEdit()
+        self.id_input.setText(self.visitor_data['visitorid'])
+        id_layout.addWidget(id_label)
+        id_layout.addWidget(self.id_input)
+        basic_layout.addLayout(id_layout)
+        
+        layout.addWidget(basic_frame)
+        
+        properties_frame = QFrame()
+        properties_frame.setFrameShape(QFrame.StyledPanel)
+        properties_layout = QVBoxLayout(properties_frame)
+        properties_layout.setContentsMargins(12, 12, 12, 12)
+        
+        properties_title = QLabel("Properties")
+        properties_title.setAlignment(Qt.AlignCenter)
+        font = properties_title.font()
+        font.setBold(True)
+        font.setPointSize(12)
+        properties_title.setFont(font)
+        properties_layout.addWidget(properties_title)
+        
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_content = QWidget()
+        self.properties_layout = QVBoxLayout(scroll_content)
+        self.properties_layout.setContentsMargins(8, 8, 8, 8)
+        self.properties_layout.setSpacing(8)
+        
+        self.property_inputs = {}
+        for key, value in self.visitor_data.get('properties', {}).items():
+            self.add_property_field(key, value)
+        
+        scroll.setWidget(scroll_content)
+        properties_layout.addWidget(scroll)
+        
+        add_property_btn = QPushButton("Add Property")
+        add_property_btn.clicked.connect(lambda: self.add_property_field())
+        properties_layout.addWidget(add_property_btn)
+        
+        layout.addWidget(properties_frame)
+        
+        button_layout = QHBoxLayout()
+        
+        save_btn = QPushButton("Save Changes")
+        save_btn.setMinimumHeight(40)
+        save_btn.clicked.connect(self.save_changes)
+        
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.setMinimumHeight(40)
+        cancel_btn.clicked.connect(self.reject)
+        
+        button_layout.addWidget(save_btn)
+        button_layout.addWidget(cancel_btn)
+        
+        layout.addLayout(button_layout)
+    
+    def add_property_field(self, key="", value=""):
+        field_layout = QHBoxLayout()
+        
+        key_input = QLineEdit()
+        key_input.setPlaceholderText("Property Name")
+        key_input.setText(key)
+        
+        value_input = QLineEdit()
+        value_input.setPlaceholderText("Value")
+        value_input.setText(str(value))
+        
+        remove_btn = QPushButton("×")
+        remove_btn.setFixedWidth(30)
+        remove_btn.clicked.connect(lambda: self.remove_property_field(field_layout))
+        
+        field_layout.addWidget(key_input)
+        field_layout.addWidget(value_input)
+        field_layout.addWidget(remove_btn)
+        
+        container = QWidget()
+        container.setLayout(field_layout)
+        self.properties_layout.addWidget(container)
+        
+        field_layout.setProperty("container", container)
+    
+    def remove_property_field(self, field_layout):
+        container = field_layout.property("container")
+        if container:
+            container.deleteLater()
+    
+    def save_changes(self):
+        name = self.name_input.text().strip()
+        visitorid = self.id_input.text().strip()
+        
+        if not name or not visitorid:
+            show_warning(
+                "Missing Information",
+                "Both name and visitor ID are required fields."
+            )
+            return
+        
+        properties = {}
+        for i in range(self.properties_layout.count()):
+            container = self.properties_layout.itemAt(i).widget()
+            if container:
+                field_layout = container.layout()
+                key_input = field_layout.itemAt(0).widget()
+                value_input = field_layout.itemAt(1).widget()
+                
+                key = key_input.text().strip()
+                value = value_input.text().strip()
+                
+                if key:
+                    properties[key] = value
+        
+        update_data = {}
+        if name != self.visitor_data['name']:
+            update_data['name'] = name
+        if visitorid != self.visitor_data['visitorid']:
+            update_data['visitorid'] = visitorid
+        if properties != self.visitor_data.get('properties', {}):
+            update_data['properties'] = properties
+        
+        if update_data:
+            confirm_dialog = QDialog(self)
+            confirm_dialog.setWindowTitle("Confirm Changes")
+            
+            layout = QVBoxLayout(confirm_dialog)
+            
+            message = QLabel("Are you sure you want to save these changes?")
+            layout.addWidget(message)
+            
+            checkbox = QCheckBox("I confirm these changes are correct")
+            layout.addWidget(checkbox)
+            
+            buttons = QDialogButtonBox(
+                QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+            )
+            ok_button = buttons.button(QDialogButtonBox.Ok)
+            ok_button.setEnabled(False)
+            
+            checkbox.stateChanged.connect(
+                lambda state: ok_button.setEnabled(state == 2)  # Qt.Checked is 2
+            )
+            
+            buttons.accepted.connect(confirm_dialog.accept)
+            buttons.rejected.connect(confirm_dialog.reject)
+            layout.addWidget(buttons)
+            
+            if confirm_dialog.exec() == QDialog.Accepted:
+                self.api_client.response_received.disconnect()
+                self.api_client.response_received.connect(self.on_update_success)
+                self.api_client.update_visitor(self.visitor_data['visitorid'], update_data)
+        else:
+            self.reject()
+    
+    def on_update_success(self, response):
+        if response and "visitor" in response:
+            self.api_client.response_received.disconnect(self.on_update_success)
+            self.accept()
+            if self.parent():
+                self.parent().accept()
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    
+    test_visitor = {
+        "name": "John Doe",
+        "visitorid": "V12345",
+        "inside": True,
+        "properties": {
+            "Company": "Acme Inc",
+            "Badge": "B123",
+            "Purpose": "Meeting"
+        }
+    }
+    
+    dialog = EditVisitorDialog(test_visitor)
+    dialog.show()
+    sys.exit(app.exec()) 

--- a/frontend/app/views/visitor/edit_visitor_dialog.py
+++ b/frontend/app/views/visitor/edit_visitor_dialog.py
@@ -32,45 +32,45 @@ class EditVisitorDialog(QDialog):
         super().__init__(parent)
         self.visitor_data = visitor_data
         self.api_client = ApiClient.get_instance()
-        
+
         self.setWindowTitle("Edit Visitor")
         self.setMinimumSize(500, 600)
-        
+
         self.setup_ui()
-        
+
     def setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
         layout.setSpacing(12)
-        
+
         basic_frame = QFrame()
         basic_frame.setFrameShape(QFrame.StyledPanel)
         basic_layout = QVBoxLayout(basic_frame)
         basic_layout.setContentsMargins(12, 12, 12, 12)
-        
+
         name_layout = QHBoxLayout()
         name_label = QLabel("Name:")
         self.name_input = QLineEdit()
-        self.name_input.setText(self.visitor_data['name'])
+        self.name_input.setText(self.visitor_data["name"])
         name_layout.addWidget(name_label)
         name_layout.addWidget(self.name_input)
         basic_layout.addLayout(name_layout)
-        
+
         id_layout = QHBoxLayout()
         id_label = QLabel("Visitor ID:")
         self.id_input = QLineEdit()
-        self.id_input.setText(self.visitor_data['visitorid'])
+        self.id_input.setText(self.visitor_data["visitorid"])
         id_layout.addWidget(id_label)
         id_layout.addWidget(self.id_input)
         basic_layout.addLayout(id_layout)
-        
+
         layout.addWidget(basic_frame)
-        
+
         properties_frame = QFrame()
         properties_frame.setFrameShape(QFrame.StyledPanel)
         properties_layout = QVBoxLayout(properties_frame)
         properties_layout.setContentsMargins(12, 12, 12, 12)
-        
+
         properties_title = QLabel("Properties")
         properties_title.setAlignment(Qt.AlignCenter)
         font = properties_title.font()
@@ -78,83 +78,82 @@ class EditVisitorDialog(QDialog):
         font.setPointSize(12)
         properties_title.setFont(font)
         properties_layout.addWidget(properties_title)
-        
+
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll_content = QWidget()
         self.properties_layout = QVBoxLayout(scroll_content)
         self.properties_layout.setContentsMargins(8, 8, 8, 8)
         self.properties_layout.setSpacing(8)
-        
+
         self.property_inputs = {}
-        for key, value in self.visitor_data.get('properties', {}).items():
+        for key, value in self.visitor_data.get("properties", {}).items():
             self.add_property_field(key, value)
-        
+
         scroll.setWidget(scroll_content)
         properties_layout.addWidget(scroll)
-        
+
         add_property_btn = QPushButton("Add Property")
         add_property_btn.clicked.connect(lambda: self.add_property_field())
         properties_layout.addWidget(add_property_btn)
-        
+
         layout.addWidget(properties_frame)
-        
+
         button_layout = QHBoxLayout()
-        
+
         save_btn = QPushButton("Save Changes")
         save_btn.setMinimumHeight(40)
         save_btn.clicked.connect(self.save_changes)
-        
+
         cancel_btn = QPushButton("Cancel")
         cancel_btn.setMinimumHeight(40)
         cancel_btn.clicked.connect(self.reject)
-        
+
         button_layout.addWidget(save_btn)
         button_layout.addWidget(cancel_btn)
-        
+
         layout.addLayout(button_layout)
-    
+
     def add_property_field(self, key="", value=""):
         field_layout = QHBoxLayout()
-        
+
         key_input = QLineEdit()
         key_input.setPlaceholderText("Property Name")
         key_input.setText(key)
-        
+
         value_input = QLineEdit()
         value_input.setPlaceholderText("Value")
         value_input.setText(str(value))
-        
+
         remove_btn = QPushButton("×")
         remove_btn.setFixedWidth(30)
         remove_btn.clicked.connect(lambda: self.remove_property_field(field_layout))
-        
+
         field_layout.addWidget(key_input)
         field_layout.addWidget(value_input)
         field_layout.addWidget(remove_btn)
-        
+
         container = QWidget()
         container.setLayout(field_layout)
         self.properties_layout.addWidget(container)
-        
+
         field_layout.setProperty("container", container)
-    
+
     def remove_property_field(self, field_layout):
         container = field_layout.property("container")
         if container:
             container.deleteLater()
-    
+
     def save_changes(self):
         name = self.name_input.text().strip()
         visitorid = self.id_input.text().strip()
-        
+
         if not name or not visitorid:
             show_warning(
-                "Missing Information",
-                "Both name and visitor ID are required fields."
+                "Missing Information", "Both name and visitor ID are required fields."
             )
             return
-        
+
         properties = {}
         for i in range(self.properties_layout.count()):
             container = self.properties_layout.itemAt(i).widget()
@@ -162,54 +161,54 @@ class EditVisitorDialog(QDialog):
                 field_layout = container.layout()
                 key_input = field_layout.itemAt(0).widget()
                 value_input = field_layout.itemAt(1).widget()
-                
+
                 key = key_input.text().strip()
                 value = value_input.text().strip()
-                
+
                 if key:
                     properties[key] = value
-        
+
         update_data = {}
-        if name != self.visitor_data['name']:
-            update_data['name'] = name
-        if visitorid != self.visitor_data['visitorid']:
-            update_data['visitorid'] = visitorid
-        if properties != self.visitor_data.get('properties', {}):
-            update_data['properties'] = properties
-        
+        if name != self.visitor_data["name"]:
+            update_data["name"] = name
+        if visitorid != self.visitor_data["visitorid"]:
+            update_data["visitorid"] = visitorid
+        if properties != self.visitor_data.get("properties", {}):
+            update_data["properties"] = properties
+
         if update_data:
             confirm_dialog = QDialog(self)
             confirm_dialog.setWindowTitle("Confirm Changes")
-            
+
             layout = QVBoxLayout(confirm_dialog)
-            
+
             message = QLabel("Are you sure you want to save these changes?")
             layout.addWidget(message)
-            
+
             checkbox = QCheckBox("I confirm these changes are correct")
             layout.addWidget(checkbox)
-            
-            buttons = QDialogButtonBox(
-                QDialogButtonBox.Ok | QDialogButtonBox.Cancel
-            )
+
+            buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
             ok_button = buttons.button(QDialogButtonBox.Ok)
             ok_button.setEnabled(False)
-            
+
             checkbox.stateChanged.connect(
                 lambda state: ok_button.setEnabled(state == 2)  # Qt.Checked is 2
             )
-            
+
             buttons.accepted.connect(confirm_dialog.accept)
             buttons.rejected.connect(confirm_dialog.reject)
             layout.addWidget(buttons)
-            
+
             if confirm_dialog.exec() == QDialog.Accepted:
                 self.api_client.response_received.disconnect()
                 self.api_client.response_received.connect(self.on_update_success)
-                self.api_client.update_visitor(self.visitor_data['visitorid'], update_data)
+                self.api_client.update_visitor(
+                    self.visitor_data["visitorid"], update_data
+                )
         else:
             self.reject()
-    
+
     def on_update_success(self, response):
         if response and "visitor" in response:
             self.api_client.response_received.disconnect(self.on_update_success)
@@ -220,18 +219,14 @@ class EditVisitorDialog(QDialog):
 
 if __name__ == "__main__":
     app = QApplication(sys.argv)
-    
+
     test_visitor = {
         "name": "John Doe",
         "visitorid": "V12345",
         "inside": True,
-        "properties": {
-            "Company": "Acme Inc",
-            "Badge": "B123",
-            "Purpose": "Meeting"
-        }
+        "properties": {"Company": "Acme Inc", "Badge": "B123", "Purpose": "Meeting"},
     }
-    
+
     dialog = EditVisitorDialog(test_visitor)
     dialog.show()
-    sys.exit(app.exec()) 
+    sys.exit(app.exec())

--- a/frontend/app/views/visitor/visitor_details_dialog.py
+++ b/frontend/app/views/visitor/visitor_details_dialog.py
@@ -27,6 +27,7 @@ from PySide6.QtCore import Qt
 from app.core.api_client import ApiClient
 from app.utils.log import Log
 from app.views.logs.logs_dialog import LogsDialog
+from app.views.visitor.edit_visitor_dialog import EditVisitorDialog
 
 
 class VisitorDetailsDialog(QDialog):
@@ -86,6 +87,7 @@ class VisitorDetailsDialog(QDialog):
             scroll_layout.setContentsMargins(8, 8, 8, 8)
             scroll_layout.setSpacing(8)
 
+            self.property_edits = {}
             for key, value in properties.items():
                 line_edit = QLineEdit()
                 line_edit.setText(f"{key}: {value}")
@@ -93,7 +95,7 @@ class VisitorDetailsDialog(QDialog):
                 line_edit.setReadOnly(True)
                 line_edit.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
                 line_edit.adjustSize()
-
+                self.property_edits[key] = line_edit
                 scroll_layout.addWidget(line_edit)
 
             scroll.setWidget(scroll_content)
@@ -104,6 +106,12 @@ class VisitorDetailsDialog(QDialog):
             properties_layout.addWidget(self.no_properties_label)
 
         self.layout.addWidget(self.properties_frame)
+
+        # Add edit button
+        self.edit_button = QPushButton("Edit Visitor")
+        self.edit_button.setMinimumHeight(40)
+        self.edit_button.clicked.connect(self.edit_visitor)
+        self.layout.addWidget(self.edit_button)
 
         isInside = self.visitor_data["inside"]
         self.toggle_button = QPushButton(f"Mark {'Outside' if isInside else 'Inside'}")
@@ -167,6 +175,12 @@ class VisitorDetailsDialog(QDialog):
     def on_logs_received(self, data):
         self.api_client.response_received.disconnect(self.on_logs_received)
         LogsDialog(data).exec()
+
+    def edit_visitor(self):
+        dialog = EditVisitorDialog(self.visitor_data, self)
+        if dialog.exec() == QDialog.Accepted:
+            # The edit dialog will handle closing both dialogs
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the ability to modify existing visitors with a dedicated edit dialog.

Changes:
Backend:
- Add PUT endpoint `/visitors/{visitor_id}` for updating visitor details
- Add `update_visitor_details` CRUD function supporting partial updates
- Update `VisitorUpdate` schema to handle optional fields

Frontend:
- Create new `EditVisitorDialog` with:
  - Clear sections for basic info and properties
  - Pre-filled input fields
  - Add/remove property functionality
  - Scrollable properties area
- Add confirmation dialog with checkbox for changes
- Update `VisitorDetailsDialog` to use the new edit dialog
- Add proper dialog closing behavior
- Add `update_visitor` method to `ApiClient`